### PR TITLE
readme: note that wildcards might not work in every shell

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,8 @@
 
 ## Installation
 
+Before installing, ensure you have Node.js version `>=16.17`.
+
 ```shell
 npm install -g gtfs-via-postgres
 ```


### PR DESCRIPTION
Update readme to specify nodejs requirements. I ran into an error when using v`16.15.0` but it wasnt clear why 

```
nvm\v16.15.0\node_modules\gtfs-via-postgres\cli.js:10
} = parseArgs({
    ^

TypeError: parseArgs is not a function
```