### PR TITLE
Change shape_dist_traveled parsing

### DIFF
--- a/lib/stop_times.js
+++ b/lib/stop_times.js
@@ -78,7 +78,7 @@ const formatStopTimesRow = (s) => {
 		s.stop_headsign || null,
 		s.pickup_type ? pickupDropOffType(s.pickup_type) : null,
 		s.drop_off_type ? pickupDropOffType(s.drop_off_type) : null,
-		s.shape_dist_traveled ? parseInt(s.shape_dist_traveled) : null,
+		s.shape_dist_traveled ? parseFloat(s.shape_dist_traveled) : null,
 		s.timepoint ? timepoint(s.timepoint) : null,
 	]
 }


### PR DESCRIPTION
In the `stop_times` tables, `shape_dist_traveled` has the `REAL` data type but is parsed as an int using `parseInt`. This PR parses `shape_dist_travelled` using `parseFloat`.