### PR TITLE
Add transfer types

### DIFF
--- a/lib/transfers.js
+++ b/lib/transfers.js
@@ -7,6 +7,8 @@ CREATE TYPE "${opt.schema}".transfer_type_v AS ENUM (
 	, 'timed' -- 1 - Timed transfer point between two routes. The departing vehicle is expected to wait for the arriving one and leave sufficient time for a rider to transfer between routes.
 	, 'minimum_time' -- 2 – Transfer requires a minimum amount of time between arrival and departure to ensure a connection. The time required to transfer is specified by min_transfer_time.
 	, 'impossible' -- 3 - Transfers are not possible between routes at the location.
+	, 'in_seat' -- 4 - Passengers can transfer from one trip to another by staying onboard the same vehicle (an "in-seat transfer").
+	, 're_board' -- 5 - In-seat transfers are not allowed between sequential trips. The passenger must alight from the vehicle and re-board.
 );
 CREATE CAST ("${opt.schema}".transfer_type_v AS text) WITH INOUT AS IMPLICIT;
 
@@ -56,6 +58,8 @@ const transferType = (val) => {
 	if (val === '1') return 'timed'
 	if (val === '2') return 'minimum_time'
 	if (val === '3') return 'impossible'
+	if (val === '4') return 'in_seat'
+	if (val === '5') return 're_board'
 	throw new Error('invalid/unsupported transfer_type: ' + val)
 }
 


### PR DESCRIPTION
This PR adds support for `transfer_type=4` and `=5` in `transfers.txt`.

[https://gtfs.org/documentation/schedule/reference/#transferstxt](https://gtfs.org/documentation/schedule/reference/#transferstxt)